### PR TITLE
Build Xwayland for legacy applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+libepoxy
+xorgproto
+libxcvt
+xserver
 Waybar
 kanshi
 sway


### PR DESCRIPTION
Because some applications still need X11 to run, this change adds
build steps for XWayland.