### PR TITLE
Fix ``fatal error: wlr/render/allocator.h: No such file or directory`…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ wf: wf-config-build wayfire-build wf-shell-build wcm-build
 ## Build dependencies
 install-repos:
 	@git clone https://github.com/swaywm/sway.git || echo "Already installed"
-	@git clone https://github.com/swaywm/wlroots.git || echo "Already installed"
+	@git clone https://gitlab.freedesktop.org/wlroots/wlroots.git || echo "Already installed"
 	@git clone https://github.com/emersion/kanshi.git || echo "Already installed"
 	@git clone https://github.com/Alexays/Waybar.git || echo "Already installed"
 	@git clone https://github.com/mortie/swaylock-effects.git || echo "Already installed"

--- a/README.md
+++ b/README.md
@@ -242,4 +242,4 @@ Open `chrome://flags` and flip `WebRTC PipeWire support` to `enabled`. Should wo
 It looks like this option has disappeared and is not available anymore.
 
 # Known issues
-Nothing at the moment.
+ * `fatal error: wlr/render/allocator.h: No such file or directory` or some other similar build errors when building wlroots: the library recently moved from github to freedesktop's gitlab. Simply delete the `wlroots` folder and run `make install-repos`


### PR DESCRIPTION
… and other wlroots compilation errors

wlroots recently moved to freedesktop's gitlab. Fix that and make a note on README.

Closes #10 