### PR TITLE
Add needed xcb-util dependency for rofi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,7 @@ define ROFI_WAYLAND_DEPS
 	libxcb-randr0-dev \
 	libxcb-cursor-dev \
 	libxcb-xinerama0-dev \
+	libxcb-aux-dev \
 	libstartup-notification0-dev \
 	flex \
 	bison \

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ define ROFI_WAYLAND_DEPS
 	libxcb-randr0-dev \
 	libxcb-cursor-dev \
 	libxcb-xinerama0-dev \
-	libxcb-aux-dev \
+	libxcb-util-dev \
 	libstartup-notification0-dev \
 	flex \
 	bison \


### PR DESCRIPTION
Hello,
Thanks for this project!

`make rofi` was failing due to the need of `xcb-aux` as dependency.
This MR adds it.