### PR TITLE
Peg wlroots to 0.16.0 while we sort out the new libdrm requirement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 
 # Define here which branches or tags you want to build for each project
 SWAY_VERSION ?= master
-WLROOTS_VERSION ?= master
+WLROOTS_VERSION ?= 0.16.0
 KANSHI_VERSION ?= master
 WAYBAR_VERSION ?= master
 SWAYLOCK_VERSION ?= master

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ifneq ("$(wildcard .env)","")
 endif
 
 # Define here which branches or tags you want to build for each project
-SWAY_VERSION ?= master
+SWAY_VERSION ?= 5c239eaac59f327294aceac739c6fa035456ed14
 WLROOTS_VERSION ?= 0.16.0
 KANSHI_VERSION ?= master
 WAYBAR_VERSION ?= master

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ define WLROOTS_DEPS
 	libgudev-1.0-dev \
 	libpixman-1-dev \
 	libsystemd-dev \
+	hwdata \
 	cmake \
 	libpng-dev \
 	libavutil-dev \


### PR DESCRIPTION
Temporary patch for Ubuntu Kinetic due to a new libdrm requirement.

Changes:
 * Peg wlroots to 0.16.0
 * Add hwdata as a dependency for wlroots
 * Peg sway to 5c239eaac59f327294aceac739c6fa035456ed14, just before it required wlroots >= .017