### PR TITLE
Add wldisplays to apps build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ check-ubuntu-version:
 ## Meta installation targets
 yolo: install-dependencies install-repos core apps
 core: seatd-build wlroots-build sway-build
-apps: xdg-desktop-portal-wlr-build kanshi-build waybar-build swaylock-build mako-build rofi-wayland-build wf-recorder-build clipman-build wofi-build nwg-panel-install swayimg-build
+apps: xdg-desktop-portal-wlr-build kanshi-build waybar-build swaylock-build mako-build rofi-wayland-build wf-recorder-build clipman-build wofi-build nwg-panel-install swayimg-build wdisplays-build
 wf: wf-config-build wayfire-build wf-shell-build wcm-build
 
 ## Build dependencies


### PR DESCRIPTION
First off, thanks a lot for this repo, it brings seamless installation of the sway stack to ubuntu!
 
All the dependencies and needed repositories for `wldisplays` is already managed by the Makefile, but it seems that `wldisplays-build` was missing from the `apps` target. This PR adds it.