### PR TITLE
Ubuntu 23.10 mantic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ rofi
 libgwater
 build
 libvarlink
+sway-contrib

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:lunar
+FROM ubuntu:mantic
 
 ARG NON_PRIVILEGED_USER=yolo
 

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,12 @@ ifneq ("$(wildcard .env)","")
 endif
 
 # Define here which branches or tags you want to build for each project
-SWAY_VERSION ?= master
-WLROOTS_VERSION ?= master
+
+# Nearly the newest at Oct 13th, working around https://gitlab.freedesktop.org/wlroots/wlroots/-/issues/3746
+
+SWAY_VERSION ?= 9816b59b
+WLROOTS_VERSION ?= 8a8fb76ec1d
+
 SEATD_VERSION ?= master
 LIBVARLINK_VERSION ?= master
 KANSHI_VERSION ?= master

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REQUIRED_UBUNTU_CODENAME=lunar
+REQUIRED_UBUNTU_CODENAME=mantic
 CURRENT_UBUNTU_CODENAME=$(shell lsb_release -cs)
 
 # Include environment overrides
@@ -20,7 +20,7 @@ WF_RECORDER_VERSION ?= master
 CLIPMAN_VERSION ?= master
 SWAYIMG_VERSION ?= master
 WDISPLAYS_VERSION ?= master
-XDG_DESKTOP_PORTAL_VERSION ?= v0.7.0
+XDG_DESKTOP_PORTAL_WLR_VERSION ?= master
 NWG_PANEL_VERSION ?= master
 WAYFIRE_VERSION ?= master
 WF_CONFIG_VERSION ?= master
@@ -294,7 +294,7 @@ nwg-panel-install:
 	sudo $(PIPX_ENV) pipx inject nwg-panel requests
 
 xdg-desktop-portal-wlr-build:
-	cd xdg-desktop-portal-wlr; git fetch; git checkout $(XDG_DESKTOP_PORTAL_VERSION); $(NINJA_CLEAN_BUILD_INSTALL)
+	cd xdg-desktop-portal-wlr; git fetch; git checkout $(XDG_DESKTOP_PORTAL_WLR_VERSION); $(NINJA_CLEAN_BUILD_INSTALL)
 	sudo ln -sf /usr/local/libexec/xdg-desktop-portal-wlr /usr/libexec/
 	sudo mkdir -p /usr/share/xdg-desktop-portal/portals/
 	sudo ln -sf /usr/local/share/xdg-desktop-portal/portals/wlr.portal /usr/share/xdg-desktop-portal/portals/

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ ifneq ("$(wildcard .env)","")
 endif
 
 # Define here which branches or tags you want to build for each project
-SWAY_VERSION ?= v1.8
-WLROOTS_VERSION ?= 0.16
-SEATD_VERSION ?= 0.7.0
+SWAY_VERSION ?= master
+WLROOTS_VERSION ?= master
+SEATD_VERSION ?= master
 LIBVARLINK_VERSION ?= master
 KANSHI_VERSION ?= master
 WAYBAR_VERSION ?= master

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,8 @@ define WLROOTS_DEPS
 	libavutil-dev \
 	libavcodec-dev \
 	libavformat-dev \
+	libdisplay-info-dev \
+	libliftoff-dev \
 	libxcb-composite0-dev \
 	libxcb-icccm4-dev \
 	libxcb-image0-dev \
@@ -188,12 +190,13 @@ check-ubuntu-version:
 ## Meta installation targets
 yolo: install-dependencies install-repos core apps
 core: seatd-build wlroots-build sway-build
-apps: xdg-desktop-portal-wlr-build kanshi-build waybar-build swaylock-build mako-build rofi-wayland-build wf-recorder-build clipman-build nwg-panel-install swayimg-build wdisplays-build
+apps: grimshot-install xdg-desktop-portal-wlr-build kanshi-build waybar-build swaylock-build mako-build rofi-wayland-build wf-recorder-build clipman-build nwg-panel-install swayimg-build wdisplays-build
 wf: wf-config-build wayfire-build wf-shell-build wcm-build
 
 ## Build dependencies
 install-repos:
 	@git clone https://github.com/swaywm/sway.git || echo "Already installed"
+	@git clone https://github.com/OctopusET/sway-contrib.git || echo "Already installed"
 	@git clone https://gitlab.freedesktop.org/wlroots/wlroots.git || echo "Already installed"
 	@git clone https://git.sr.ht/~emersion/kanshi || echo "Already installed"
 	@git clone https://github.com/varlink/libvarlink.git || echo "Already installed"
@@ -253,12 +256,15 @@ wlroots-build:
 
 sway-build:
 	make meson-ninja-build -e APP_FOLDER=sway -e APP_VERSION=$(SWAY_VERSION)
-	sudo cp -f sway/contrib/grimshot /usr/local/bin/
+
 ## Libs
 libvarlink-build:
 	make meson-ninja-build -e APP_FOLDER=libvarlink -e APP_VERSION=$(LIBVARLINK_VERSION)
 
 ## Apps
+grimshot-install:
+	sudo cp -f sway-contrib/grimshot /usr/local/bin/
+
 kanshi-build: libvarlink-build
 	make meson-ninja-build -e APP_FOLDER=kanshi -e APP_VERSION=$(KANSHI_VERSION)
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Sway builds for Ubuntu 23.04 (amd64)
+# Sway builds for Ubuntu 23.10 (amd64)
 
-Ubuntu 23.04 build system for sway and related tools.
+Ubuntu 23.10 build system for sway and related tools.
 
 Even though most of these tools (including sway and wlroots) are now available in Ubuntu, they move and evolve pretty quickly and I personally prefer to keep up to date with those.
 
 This repository contains a Makefile based build system for all of these. We are NOT building deb packages (see my [old repository which did](https://github.com/luispabon/sway-ubuntu-deb-build) if you want to do so), but we're directly building from source and installing as root.
 
-## Note: upgrading to Ubuntu 23.04
+## Note: upgrading from Ubuntu 22.10 or earlier
 
 You can safely ignore this note if this is the first time you're installing sway and all the other apps from this repo.
 
@@ -57,7 +57,7 @@ Make sure you do not install these via Ubuntu's package repos.
 
 ### How about older Ubuntus?
 
-There are (unmaintained) branches of this project for earlier versions of Ubuntu. They won't receive any fixes,, but if you want to use them and want to send PRs with fixes these are welcome.
+There are (unmaintained) branches of this project for earlier versions of Ubuntu. They won't receive any fixes unless contributed by the community, as I have moved on from using them. PRs more than welcome.
 
 I usually switch to the next ubuntu a few weeks before release, so typically old branches will have the very latest versions of the apps that are physically compilable given the libraries available.
 
@@ -175,7 +175,7 @@ This goes without saying, but if you're updating `wlroots` or `seatd` make sure 
 
 ## Screen sharing
 
-Ubuntu 23.04 comes with all the plumbing to make it all work:
+Ubuntu 23.10 comes with all the plumbing to make it all work:
   * pipewire 0.3
   * wireplumber
   * xdg-desktop-portal-gtk with the correct build flags
@@ -225,10 +225,6 @@ Should work out of the box on Firefox 84+ using the wayland backend.
 
 When you start screensharing, on the dialog asking you what to share tell it to "Use operating system settings" when prompted. After that, the output chooser for xdpw will kick in, as explained on the previous section.
 
-### Chromium
+### Chromium & Chrome
 
-Ubuntu's Chromium snap currently does not seem to have webrtc pipewire support.
-
-### Chrome
-
-Open `chrome://flags` and flip `WebRTC PipeWire support` to `enabled`. Should work after that.
+It should work out of the box when using the wayland backend, but if it doesn't open `chrome://flags` and ensure `WebRTC PipeWire support` is `enabled`.


### PR DESCRIPTION
**Changes:**
 * Upgrade Makefile and Dockerfile to work from ubuntu mantic
 * Sway 1.8.x won't compile anymore, so upgrade to the newest versions possible (feels like 1.9 is around the corner)
 * Peg sway and wlroots to the newest versions not affected by https://gitlab.freedesktop.org/wlroots/wlroots/-/issues/3746
 * Grimshot is no longer part of the sway repo - install from its new repository
 * Update README