### PR TITLE
Added missed dependency for rofi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,7 @@ define ROFI_WAYLAND_DEPS
 	libxcb-ewmh-dev \
 	libxcb-randr0-dev \
 	libxcb-cursor-dev \
+	libxcb-util-dev \
 	libxcb-xinerama0-dev \
 	libstartup-notification0-dev \
 	flex \


### PR DESCRIPTION
I was trying to build rofi today on a jammy system and it failed because it was missing the `xcb-aux` run-time dependency.
This was fixed by installing the `libxcb-util-dev` package to the dependency list